### PR TITLE
Fail CKV_AWS_8 if block_device is not specified

### DIFF
--- a/checkov/terraform/checks/resource/aws/LaunchConfigurationEBSEncryption.py
+++ b/checkov/terraform/checks/resource/aws/LaunchConfigurationEBSEncryption.py
@@ -26,7 +26,7 @@ class LaunchConfigurationEBSEncryption(BaseResourceCheck):
                         return CheckResult.PASSED
                 else:
                     return CheckResult.FAILED
-        return CheckResult.PASSED
+        return CheckResult.FAILED
 
 
 check = LaunchConfigurationEBSEncryption()


### PR DESCRIPTION
It is easy to create an `aws_instance` without a specified block device.  Unfortunately, the default block device is not encrypted.

This PR fails CKV_AWS_8 if no block_device is specified.